### PR TITLE
Added criteria mappers for FieldValueCriterion, LogicalAnd and LogicalOr

### DIFF
--- a/src/bundle/Resources/config/services/query.yaml
+++ b/src/bundle/Resources/config/services/query.yaml
@@ -7,3 +7,15 @@ services:
     Ibexa\Contracts\CoreSearch\Values\Query\CriterionMapper:
         arguments:
             $mappers: !tagged_iterator ibexa.core_search.criterion_mapper
+
+    Ibexa\CoreSearch\CriterionMapper\FieldValueCriterionMapper:
+        tags:
+            - { name: ibexa.core_search.criterion_mapper, priority: -100 }
+
+    Ibexa\CoreSearch\CriterionMapper\LogicalAndCriterionMapper:
+        tags:
+            - { name: ibexa.core_search.criterion_mapper, priority: -100 }
+
+    Ibexa\CoreSearch\CriterionMapper\LogicalOrCriterionMapper:
+        tags:
+            - { name: ibexa.core_search.criterion_mapper, priority: -100 }

--- a/src/lib/CriterionMapper/FieldValueCriterionMapper.php
+++ b/src/lib/CriterionMapper/FieldValueCriterionMapper.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\CoreSearch\CriterionMapper;
+
+use Ibexa\Contracts\CoreSearch\Persistence\CriterionMapper\AbstractFieldCriterionMapper;
+use Ibexa\Contracts\CoreSearch\Values\Query\Criterion\CriterionInterface;
+use Ibexa\Contracts\CoreSearch\Values\Query\Criterion\FieldValueCriterion;
+
+/**
+ * @template-extends \Ibexa\Contracts\CoreSearch\Persistence\CriterionMapper\AbstractFieldCriterionMapper<
+ *     \Ibexa\Contracts\CoreSearch\Values\Query\Criterion\FieldValueCriterion
+ * >
+ */
+final class FieldValueCriterionMapper extends AbstractFieldCriterionMapper
+{
+    public function canHandle(CriterionInterface $criterion): bool
+    {
+        return $criterion instanceof FieldValueCriterion;
+    }
+}

--- a/src/lib/CriterionMapper/LogicalAndCriterionMapper.php
+++ b/src/lib/CriterionMapper/LogicalAndCriterionMapper.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\CoreSearch\CriterionMapper;
+
+use Doctrine\Common\Collections\Expr\CompositeExpression;
+use Ibexa\Contracts\CoreSearch\Persistence\CriterionMapper\AbstractCompositeCriterionMapper;
+use Ibexa\Contracts\CoreSearch\Values\Query\Criterion\LogicalAnd;
+
+final class LogicalAndCriterionMapper extends AbstractCompositeCriterionMapper
+{
+    protected function getHandledClass(): string
+    {
+        return LogicalAnd::class;
+    }
+
+    protected function getType(): string
+    {
+        return CompositeExpression::TYPE_AND;
+    }
+}

--- a/src/lib/CriterionMapper/LogicalOrCriterionMapper.php
+++ b/src/lib/CriterionMapper/LogicalOrCriterionMapper.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\CoreSearch\CriterionMapper;
+
+use Doctrine\Common\Collections\Expr\CompositeExpression;
+use Ibexa\Contracts\CoreSearch\Persistence\CriterionMapper\AbstractCompositeCriterionMapper;
+use Ibexa\Contracts\CoreSearch\Values\Query\Criterion\LogicalOr;
+
+final class LogicalOrCriterionMapper extends AbstractCompositeCriterionMapper
+{
+    protected function getHandledClass(): string
+    {
+        return LogicalOr::class;
+    }
+
+    protected function getType(): string
+    {
+        return CompositeExpression::TYPE_OR;
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | N/A       |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

Added criterion mappers for:
* `\Ibexa\Contracts\CoreSearch\Values\Query\Criterion\FieldValueCriterion`
* `\Ibexa\Contracts\CoreSearch\Values\Query\Criterion\LogicalAnd` 
* `\Ibexa\Contracts\CoreSearch\Values\Query\Criterion\LogicalOr`

#### For QA:
N/A

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
