### PR TITLE
IBX-8470: Upgraded codebase to Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": false
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,13 @@
     "require": {
         "php": ">=8.3",
         "ibexa/core": "~5.0.x-dev",
-        "symfony/config": "^5.4",
-        "symfony/dependency-injection": "^5.4",
-        "symfony/event-dispatcher": "^5.4",
+        "symfony/config": "^6.4",
+        "symfony/dependency-injection": "^6.4",
+        "symfony/event-dispatcher": "^6.4",
         "symfony/event-dispatcher-contracts": "^2.2",
-        "symfony/http-foundation": "^5.4",
-        "symfony/http-kernel": "^5.4",
-        "symfony/yaml": "^5.4"
+        "symfony/http-foundation": "^6.4",
+        "symfony/http-kernel": "^6.4",
+        "symfony/yaml": "^6.4"
     },
     "require-dev": {
         "ibexa/behat": "~5.0.x-dev",

--- a/src/bundle/DependencyInjection/IbexaCoreSearchExtension.php
+++ b/src/bundle/DependencyInjection/IbexaCoreSearchExtension.php
@@ -20,6 +20,8 @@ final class IbexaCoreSearchExtension extends Extension implements PrependExtensi
 {
     /**
      * @param array<string, mixed> $configs
+     *
+     * @throws \Exception
      */
     public function load(array $configs, ContainerBuilder $container): void
     {

--- a/src/contracts/Persistence/CriterionMapper/AbstractFieldCriterionMapper.php
+++ b/src/contracts/Persistence/CriterionMapper/AbstractFieldCriterionMapper.php
@@ -79,10 +79,7 @@ abstract class AbstractFieldCriterionMapper implements CriterionMapperInterface
         ));
     }
 
-    /**
-     * @return mixed
-     */
-    protected function getComparisonValue(FieldValueCriterion $criterion)
+    protected function getComparisonValue(FieldValueCriterion $criterion): mixed
     {
         return $criterion->getValue();
     }

--- a/src/contracts/Values/Query/AbstractCriterionQuery.php
+++ b/src/contracts/Values/Query/AbstractCriterionQuery.php
@@ -16,7 +16,7 @@ use Ibexa\Contracts\CoreSearch\Values\Query\Criterion\CriterionInterface;
  */
 abstract class AbstractCriterionQuery
 {
-    public const DEFAULT_LIMIT = 25;
+    public const int DEFAULT_LIMIT = 25;
 
     /** @phpstan-var TCriterion|null */
     private ?CriterionInterface $query;

--- a/src/contracts/Values/Query/AbstractSortClause.php
+++ b/src/contracts/Values/Query/AbstractSortClause.php
@@ -13,10 +13,10 @@ use InvalidArgumentException;
 abstract class AbstractSortClause
 {
     /** @final */
-    public const SORT_ASC = SortDirection::ASC;
+    public const string SORT_ASC = SortDirection::ASC;
 
     /** @final */
-    public const SORT_DESC = SortDirection::DESC;
+    public const string SORT_DESC = SortDirection::DESC;
 
     /**
      * Sort direction.

--- a/src/contracts/Values/Query/Criterion/FieldValueCriterion.php
+++ b/src/contracts/Values/Query/Criterion/FieldValueCriterion.php
@@ -11,34 +11,33 @@ namespace Ibexa\Contracts\CoreSearch\Values\Query\Criterion;
 class FieldValueCriterion implements CriterionInterface
 {
     /** @final */
-    public const COMPARISON_EQ = '=';
+    public const string COMPARISON_EQ = '=';
     /** @final */
-    public const COMPARISON_NEQ = '<>';
+    public const string COMPARISON_NEQ = '<>';
     /** @final */
-    public const COMPARISON_LT = '<';
+    public const string COMPARISON_LT = '<';
     /** @final */
-    public const COMPARISON_LTE = '<=';
+    public const string COMPARISON_LTE = '<=';
     /** @final */
-    public const COMPARISON_GT = '>';
+    public const string COMPARISON_GT = '>';
     /** @final */
-    public const COMPARISON_GTE = '>=';
+    public const string COMPARISON_GTE = '>=';
     /** @final */
-    public const COMPARISON_IN = 'IN';
+    public const string COMPARISON_IN = 'IN';
     /** @final */
-    public const COMPARISON_NIN = 'NIN';
+    public const string COMPARISON_NIN = 'NIN';
     /** @final */
-    public const COMPARISON_CONTAINS = 'CONTAINS';
+    public const string COMPARISON_CONTAINS = 'CONTAINS';
     /** @final */
-    public const COMPARISON_MEMBER_OF = 'MEMBER_OF';
+    public const string COMPARISON_MEMBER_OF = 'MEMBER_OF';
     /** @final */
-    public const COMPARISON_STARTS_WITH = 'STARTS_WITH';
+    public const string COMPARISON_STARTS_WITH = 'STARTS_WITH';
     /** @final */
-    public const COMPARISON_ENDS_WITH = 'ENDS_WITH';
+    public const string COMPARISON_ENDS_WITH = 'ENDS_WITH';
 
     private string $field;
 
-    /** @var mixed */
-    private $value;
+    private mixed $value;
 
     private string $operator;
 
@@ -57,18 +56,12 @@ class FieldValueCriterion implements CriterionInterface
         return $this->field;
     }
 
-    /**
-     * @param mixed $value
-     */
-    public function setValue($value): void
+    public function setValue(mixed $value): void
     {
         $this->value = $value;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getValue()
+    public function getValue(): mixed
     {
         return $this->value;
     }

--- a/src/contracts/Values/Query/CriterionMapperInterface.php
+++ b/src/contracts/Values/Query/CriterionMapperInterface.php
@@ -19,7 +19,7 @@ interface CriterionMapperInterface
     public function canHandle(CriterionInterface $criterion): bool;
 
     /**
-     * @param C $criterion
+     * @phpstan-param C $criterion
      */
     public function handle(CriterionInterface $criterion, CriterionMapper $mapper): Expression;
 }

--- a/src/contracts/Values/Query/SortDirection.php
+++ b/src/contracts/Values/Query/SortDirection.php
@@ -13,8 +13,8 @@ namespace Ibexa\Contracts\CoreSearch\Values\Query;
  */
 class SortDirection
 {
-    public const ASC = 'ascending';
-    public const DESC = 'descending';
+    public const string ASC = 'ascending';
+    public const string DESC = 'descending';
 
     /**
      * @phpstan-assert-if-true self::ASC|self::DESC $value


### PR DESCRIPTION
> [!CAUTION]
> This is a part of bigger set of changes, to be merged together when ready
> - [x] :exclamation:  **Remove TMP commits before merge** :exclamation:

| :ticket: Issue | IBX-8470 |
|----------------|-----------|


#### Related PRs:
- https://github.com/ibexa/core/pull/447
- https://github.com/ibexa/doctrine-schema/pull/27
- https://github.com/ibexa/behat/pull/125

#### Description:

This PR bumps Symfony to v6 and improves codebase. I've added strict types to consts and missing return type(s) and I've also fixed PHPStan-specific data types type-hints to include phpstan- prefix as those are not recognized by phpDocumentor and sometimes IDE.

Except for static analysis, it's hard to say if the code works because there's 0 test coverage here. Browser tests for now will fail, until all packages are upgraded.

Key changes:

- [x] Bumped Symfony packages requirements to ^6.4
- [x] [Composer] Disallowed plugins
- [x] [PHPDoc] Added missing throws to IbexaCoreSearchExtension::load method
- [x] Added strict types to the contracts
- [x] [PHPDoc] Fixed PHPStan type-hints

#### QA:

Sanities in the form of regression tests.

#### Documentation:

No documentation required.