### PR TITLE
Fix AbstractCriterionQuery phpdoc

### DIFF
--- a/src/contracts/Values/Query/AbstractCriterionQuery.php
+++ b/src/contracts/Values/Query/AbstractCriterionQuery.php
@@ -107,7 +107,7 @@ abstract class AbstractCriterionQuery
     }
 
     /**
-     * @param array<int, AbstractSortClause>
+     * @param array<int, AbstractSortClause> $sortClauses
      * @phpstan-param TSortClause[] $sortClauses
      */
     final public function setSortClauses(array $sortClauses): void

--- a/src/contracts/Values/Query/AbstractCriterionQuery.php
+++ b/src/contracts/Values/Query/AbstractCriterionQuery.php
@@ -18,10 +18,10 @@ abstract class AbstractCriterionQuery
 {
     public const DEFAULT_LIMIT = 25;
 
-    /** @var TCriterion|null */
+    /** @phpstan-var TCriterion|null */
     private ?CriterionInterface $query;
 
-    /** @var TSortClause[] */
+    /** @phpstan-var TSortClause[] */
     private array $sortClauses;
 
     private ?int $limit;
@@ -29,8 +29,9 @@ abstract class AbstractCriterionQuery
     private int $offset;
 
     /**
-     * @param TSortClause[]|null $sortClauses
-     * @param TCriterion|null $query
+     * @param array<int, AbstractSortClause>|null $sortClauses
+     * @phpstan-param TSortClause[]|null $sortClauses
+     * @phpstan-param TCriterion|null $query
      */
     public function __construct(
         ?CriterionInterface $query = null,
@@ -45,7 +46,7 @@ abstract class AbstractCriterionQuery
     }
 
     /**
-     * @param TCriterion|null $criterion
+     * @phpstan-param TCriterion|null $criterion
      */
     final public function setQuery(?CriterionInterface $criterion): void
     {
@@ -53,7 +54,7 @@ abstract class AbstractCriterionQuery
     }
 
     /**
-     * @return TCriterion|null
+     * @phpstan-return TCriterion|null
      */
     final public function getQuery(): ?CriterionInterface
     {
@@ -86,7 +87,8 @@ abstract class AbstractCriterionQuery
     }
 
     /**
-     * @return TSortClause[]
+     * @return array<int, AbstractSortClause>
+     * @phpstan-return TSortClause[]
      */
     final public function getSortClauses(): array
     {
@@ -102,6 +104,7 @@ abstract class AbstractCriterionQuery
     }
 
     /**
+     * @param array<int, AbstractSortClause>
      * @phpstan-param TSortClause[] $sortClauses
      */
     final public function setSortClauses(array $sortClauses): void

--- a/src/contracts/Values/Query/AbstractCriterionQuery.php
+++ b/src/contracts/Values/Query/AbstractCriterionQuery.php
@@ -23,6 +23,7 @@ abstract class AbstractCriterionQuery
 
     /**
      * @var array<int, AbstractSortClause>
+     *
      * @phpstan-var TSortClause[]
      */
     private array $sortClauses;
@@ -33,6 +34,7 @@ abstract class AbstractCriterionQuery
 
     /**
      * @param array<int, AbstractSortClause>|null $sortClauses
+     *
      * @phpstan-param TSortClause[]|null $sortClauses
      * @phpstan-param TCriterion|null $query
      */
@@ -91,6 +93,7 @@ abstract class AbstractCriterionQuery
 
     /**
      * @return array<int, AbstractSortClause>
+     *
      * @phpstan-return TSortClause[]
      */
     final public function getSortClauses(): array
@@ -108,6 +111,7 @@ abstract class AbstractCriterionQuery
 
     /**
      * @param array<int, AbstractSortClause> $sortClauses
+     *
      * @phpstan-param TSortClause[] $sortClauses
      */
     final public function setSortClauses(array $sortClauses): void

--- a/src/contracts/Values/Query/AbstractCriterionQuery.php
+++ b/src/contracts/Values/Query/AbstractCriterionQuery.php
@@ -21,7 +21,10 @@ abstract class AbstractCriterionQuery
     /** @phpstan-var TCriterion|null */
     private ?CriterionInterface $query;
 
-    /** @phpstan-var TSortClause[] */
+    /**
+     * @var array<int, AbstractSortClause>
+     * @phpstan-var TSortClause[]
+     */
     private array $sortClauses;
 
     private ?int $limit;


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

#### Description:

Issue: PHP API Reference for this class quotes non-existing TCriterion and TSortClause classes.
https://doc.ibexa.co/en/latest/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-Catalog-CatalogQuery.html#methods

Fixes:
- Add phpstan- prefix to tags using those template.
- Add a standard tag for array key and value types.

Note: Maybe some phpstan- tags are useless because semantically declaring the same thing than the standard one.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:

PHP API Reference is regenerated at each new release.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
