### PR TITLE
Allow dispatcher contracts 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "symfony/config": "^5.4",
         "symfony/dependency-injection": "^5.4",
         "symfony/event-dispatcher": "^5.4",
-        "symfony/event-dispatcher-contracts": "^2.2",
+        "symfony/event-dispatcher-contracts": "^2.2 || ^3.0",
         "symfony/http-foundation": "^5.4",
         "symfony/http-kernel": "^5.4",
         "symfony/yaml": "^5.4"


### PR DESCRIPTION
#### Description:
Some of the useful bundles out there require dispatcher contracts 3.x and cannot be installed on Ibexa 4.6.

As far as I can see, there is no breaking changes apart from adding PHP 8 support, which is not an issue here since we only allow extra version, without disabling older ones.